### PR TITLE
SA-16-Implement lambda for metrics endpoint

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module github.com/CorreaJose13/StockAPI
 go 1.24.2
 
 require (
+	github.com/aws/aws-lambda-go v1.48.0
 	github.com/google/generative-ai-go v0.19.0
 	github.com/joho/godotenv v1.5.1
 	github.com/lib/pq v1.10.9

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -12,6 +12,8 @@ cloud.google.com/go/compute/metadata v0.5.0/go.mod h1:aHnloV2TPI38yx4s9+wAZhHykW
 cloud.google.com/go/longrunning v0.5.7 h1:WLbHekDbjK1fVFD3ibpFFVoyizlLRl73I7YKuAKilhU=
 cloud.google.com/go/longrunning v0.5.7/go.mod h1:8GClkudohy1Fxm3owmBGid8W0pSgodEMwEAztp38Xng=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/aws/aws-lambda-go v1.48.0 h1:1aZUYsrJu0yo5fC4z+Rba1KhNImXcJcvHu763BxoyIo=
+github.com/aws/aws-lambda-go v1.48.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/backend/internal/analysis/summary.go
+++ b/backend/internal/analysis/summary.go
@@ -1,10 +1,10 @@
 package analysis
 
 type StockSummary struct {
-	TotalStocks    int
-	PositiveChange int
-	NegativeChange int
-	NoChange       int
+	TotalStocks    int `json:"total_stocks"`
+	PositiveChange int `json:"positive_change"`
+	NegativeChange int `json:"negative_change"`
+	NoChange       int `json:"no_change"`
 }
 
 func (a *Analysis) GetSummary() *StockSummary {

--- a/backend/internal/api/response/response.go
+++ b/backend/internal/api/response/response.go
@@ -1,0 +1,36 @@
+package response
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+)
+
+var (
+	responseHeaders = map[string]string{
+		"Content-Type": "application/json",
+	}
+)
+
+func Success(data any) (events.APIGatewayProxyResponse, error) {
+	responseBytes, err := json.Marshal(data)
+	if err != nil {
+		return Error(http.StatusInternalServerError, "Failed to serialize response data")
+	}
+
+	return events.APIGatewayProxyResponse{
+		StatusCode: http.StatusOK,
+		Headers:    responseHeaders,
+		Body:       string(responseBytes),
+	}, nil
+}
+
+func Error(statusCode int, message string) (events.APIGatewayProxyResponse, error) {
+	return events.APIGatewayProxyResponse{
+		StatusCode: statusCode,
+		Headers:    responseHeaders,
+		Body:       fmt.Sprintf(`{"message":"%s"}`, message),
+	}, nil
+}

--- a/backend/internal/functions/metrics/metrics.go
+++ b/backend/internal/functions/metrics/metrics.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+
+	"github.com/CorreaJose13/StockAPI/config"
+	"github.com/CorreaJose13/StockAPI/internal/analysis"
+	"github.com/CorreaJose13/StockAPI/internal/api/response"
+	"github.com/CorreaJose13/StockAPI/internal/db"
+	"github.com/CorreaJose13/StockAPI/internal/repository"
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+var (
+	dbString        string
+	initErr         error
+	errMissingDBURL = errors.New("db url cannot be empty")
+)
+
+func init() {
+	dbString = os.Getenv("DB_URL")
+	if dbString == "" {
+		initErr = errMissingDBURL
+	}
+}
+
+func handler(ctx context.Context, req events.APIGatewayProxyRequest) (events.APIGatewayProxyResponse, error) {
+	if initErr != nil {
+		return events.APIGatewayProxyResponse{}, initErr
+	}
+
+	cfg := &config.Config{
+		DBURL: dbString,
+	}
+
+	repo, err := db.NewPostgresRepository(cfg)
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, err.Error())
+	}
+
+	defer repo.Close()
+
+	repository.SetStockRepository(repo)
+
+	stocks, err := repository.GetStocks(ctx)
+	if err != nil {
+		return response.Error(http.StatusInternalServerError, err.Error())
+	}
+
+	analysis := analysis.NewAnalysis(stocks)
+
+	return response.Success(analysis.GetSummary())
+}
+
+func main() {
+	lambda.Start(handler)
+}


### PR DESCRIPTION
## What?
This PR creates a lambda to retrieve metrics like the total of the stocks in the db, and stock count with positive, negative or neutral changes to its target price
## Why?
To later creation of an apigateway endpoint to display this info as a feature in the UI
## How?
-Imported AWS SDK for Go
-Created success and error response wrappers to reuse later in the creation of more lambdas
-Implement lambda function with appropriate error handling
